### PR TITLE
UNUSED argc

### DIFF
--- a/sshell.c
+++ b/sshell.c
@@ -28,6 +28,8 @@ void executeBuiltin(char **command, char *commandString);
  */
 int main(int argc, char *argv[])
 {
+    (void)argc; //UNUSED variable, so casting it to the void to make it readable
+        
     // Buffer for user command input
     printPrompt();
 


### PR DESCRIPTION
To prevent bugs in the future like warning messages, you can `(void)` variables like argc. This will help others to save time trying to figure out where is `argc` used. There is also another unused variable, but I want you to find it for practice. I hope this helps :)!